### PR TITLE
Add background-color when toggle is enabled

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -531,6 +531,11 @@ img
     background-color: var(--interactive-accent);
 }
 
+.checkbox-container.is-enabled:after 
+{
+    background-color: var(--bg5-dark);
+}
+
 .mod-cta
 {
     color: var(--background-secondary-alt) !important;


### PR DESCRIPTION
Not sure if this on your radar at all, but it might be an easy fix for enabling the background color when a toggle switch is enabled.

Currently, the toggle "dot" is invisible against the green background when the toggle is enabled:

![img01](https://user-images.githubusercontent.com/6901379/153698457-d3bb1fd9-6f1b-4ade-8c45-1daaa1e42f41.jpg)
![img02](https://user-images.githubusercontent.com/6901379/153698464-23b22095-d1fa-4576-94d8-9c8e45405307.jpg)

With the css fix applied:
![img03](https://user-images.githubusercontent.com/6901379/153698473-ed66605e-8383-41d9-ba0b-87c9a7dc7c6e.jpg)
