### PR TITLE
Light mode color tweaks

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -178,7 +178,7 @@ body {
     --text-mark:                  rgba(215, 153, 33, 0.4); /* light-yellow */
     --pre-code:                   var(--bg1-light);
     --text-highlight-bg:          var(--light-dim-aqua);
-    --interactive-accent:         var(--bg5-light);
+    --interactive-accent:         var(--light-dim-aqua);
     --interactive-before:         var(--bg5-light);
     --background-modifier-border: var(--bg5-light);
     --text-accent:                var(--light-dim-green);

--- a/obsidian.css
+++ b/obsidian.css
@@ -177,7 +177,7 @@ body {
     --text-a-hover:               var(--light-blue);
     --text-mark:                  rgba(215, 153, 33, 0.4); /* light-yellow */
     --pre-code:                   var(--bg1-light);
-    --text-highlight-bg:          var(--light-dim-aqua);
+    --text-highlight-bg:          var(--bg4-light);
     --interactive-accent:         var(--light-dim-aqua);
     --interactive-before:         var(--bg5-light);
     --background-modifier-border: var(--bg5-light);

--- a/obsidian.css
+++ b/obsidian.css
@@ -177,7 +177,7 @@ body {
     --text-a-hover:               var(--light-blue);
     --text-mark:                  rgba(215, 153, 33, 0.4); /* light-yellow */
     --pre-code:                   var(--bg1-light);
-    --text-highlight-bg:          var(--light-dim-green);
+    --text-highlight-bg:          var(--light-dim-aqua);
     --interactive-accent:         var(--bg5-light);
     --interactive-before:         var(--bg5-light);
     --background-modifier-border: var(--bg5-light);


### PR DESCRIPTION
After working with the theme for a little longer, I felt the need to tweak some things.
- The contrast of highlighting was a little to low for my taste (3c8347cc7160092312e7c5b70387744b9f3027d4)
- I wanted the bar of the quote to be a little more colourful, like in the dark theme (bebd0b2b4693d7addee1d3ca2d8f7bf513c6c3c4)

Maybe it would be helpful to update the screenshots for the readme.